### PR TITLE
Expose event channel from telegram bot

### DIFF
--- a/bridge/src/commonMain/kotlin/ru/herobrine1st/matrix/bridge/telegram/util/CallbackWrapper.kt
+++ b/bridge/src/commonMain/kotlin/ru/herobrine1st/matrix/bridge/telegram/util/CallbackWrapper.kt
@@ -1,0 +1,28 @@
+package ru.herobrine1st.matrix.bridge.telegram.util
+
+import kotlinx.coroutines.Job
+
+internal class CallbackWrapper<T>(
+    private val value: T,
+) {
+    private val _job = Job()
+    val job: Job get() = _job
+
+    internal suspend inline fun use(block: suspend (T) -> Unit) {
+        try {
+            block(value)
+        } catch (e: Throwable) {
+            if (!_job.completeExceptionally(e)) {
+                throw IllegalStateException("This can only be used once!")
+                    .apply {
+                        addSuppressed(e)
+                    }
+            }
+            throw e
+        }
+
+        if (!_job.complete()) {
+            throw IllegalStateException("This can only be used once!")
+        }
+    }
+}

--- a/bridge/src/commonMain/kotlin/ru/herobrine1st/matrix/bridge/telegram/util/ChannelCopyingHandler.kt
+++ b/bridge/src/commonMain/kotlin/ru/herobrine1st/matrix/bridge/telegram/util/ChannelCopyingHandler.kt
@@ -1,0 +1,20 @@
+package ru.herobrine1st.matrix.bridge.telegram.util
+
+import com.github.kotlintelegrambot.Bot
+import com.github.kotlintelegrambot.dispatcher.handlers.Handler
+import com.github.kotlintelegrambot.entities.Update
+import kotlinx.coroutines.channels.SendChannel
+
+internal class ChannelCopyingHandler(
+    private val channel: SendChannel<CallbackWrapper<Update>>,
+) : Handler {
+    override fun checkUpdate(update: Update): Boolean = true
+    override suspend fun handleUpdate(
+        bot: Bot,
+        update: Update,
+    ) {
+        val wrapper = CallbackWrapper(update)
+        channel.send(wrapper)
+        wrapper.job.join()
+    }
+}


### PR DESCRIPTION
Currently, kotlin-telegram-bot only allows to add event handlers on `Bot` instance creation. Furthermore, imperative event handling is not possible at all.

This PR adds ability to add event handlers after bot instance is constructed. This is done by redirecting all updates into channel and waiting on update consumption.

This is a workaround of an architectural limitation in trixnity-bridge and I'm currently working on allowing push-like event sources. However, kotlin-telegram-bot would have no issue exposing explicit methods to get updates instead of undermining structured concurrency, so there are two architectural limitations and they are clashed here.