### PR TITLE
Merge service files

### DIFF
--- a/bridge/build.gradle.kts
+++ b/bridge/build.gradle.kts
@@ -10,6 +10,7 @@ tasks.shadowJar {
     manifest {
         attributes["Main-Class"] = "ru.herobrine1st.matrix.bridge.telegram.MainKt"
     }
+    mergeServiceFiles()
 }
 
 kotlin {

--- a/bridge/src/jvmMain/resources/META-INF/services/io.r2dbc.spi.ConnectionFactoryProvider
+++ b/bridge/src/jvmMain/resources/META-INF/services/io.r2dbc.spi.ConnectionFactoryProvider
@@ -1,2 +1,0 @@
-io.r2dbc.postgresql.PostgresqlConnectionFactoryProvider
-io.r2dbc.pool.PoolingConnectionFactoryProvider


### PR DESCRIPTION
#10 replaced Ktor bundling plugin with gradleup/shadow due to lack of support for Kotlin Multiplatform. Ktor plugin overwrites resources by default, while gradleup/shadow includes all resources from all dependencies, even if path collides (file-roller shows multiple files with the same name). For this reason, a merged service file was included in the project.

This PR fixes a regression caused by plugin replacement. As gradleup/shadow can merge service files itself, merged service file is also removed.