### PR TITLE
chore: update trixnity-bridge to 0.1.3

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 kotlin = "2.1.10"
 ktor = "3.0.3"
-trixnity-bridge = "0.1.0-1"
+trixnity-bridge = "0.1.3"
 
 [plugins]
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }


### PR DESCRIPTION
This PR fixes failure to use contextual serializer lookup and attempts to migrate already migrated database