### PR TITLE
General fixes for bridge startup

### DIFF
--- a/bridge/build.gradle.kts
+++ b/bridge/build.gradle.kts
@@ -23,6 +23,7 @@ kotlin {
             implementation(libs.ktor.server.core)
             implementation(libs.ktor.server.callLogging)
 
+            implementation(libs.ktor.client.cio)
             implementation(libs.trixnity.bridge.core)
             implementation(libs.trixnity.bridge.compat)
             implementation(libs.kotlinLogging)

--- a/bridge/src/commonMain/kotlin/ru/herobrine1st/matrix/bridge/telegram/module/TrixnityModule.kt
+++ b/bridge/src/commonMain/kotlin/ru/herobrine1st/matrix/bridge/telegram/module/TrixnityModule.kt
@@ -46,7 +46,7 @@ fun Application.trixnityModule() {
         bridgeConfig = BridgeConfig.fromConfig(environment.config.config("bridge"))
     )
 
-    monitor.subscribe(ApplicationStarting) {
+    monitor.subscribe(ApplicationStarted) {
         runBlocking {
             worker.createAppServiceBot()
         }

--- a/bridge/src/commonMain/kotlin/ru/herobrine1st/matrix/bridge/telegram/value/MessageIdSerializer.kt
+++ b/bridge/src/commonMain/kotlin/ru/herobrine1st/matrix/bridge/telegram/value/MessageIdSerializer.kt
@@ -1,0 +1,22 @@
+package ru.herobrine1st.matrix.bridge.telegram.value
+
+import com.github.kotlintelegrambot.entities.MessageId
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+class MessageIdSerializer: KSerializer<MessageId> {
+    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("com.github.kotlintelegrambot.entities.MessageId", PrimitiveKind.LONG)
+    override fun serialize(
+        encoder: Encoder,
+        value: MessageId,
+    ) {
+        encoder.encodeLong(value.messageId)
+    }
+
+    override fun deserialize(decoder: Decoder): MessageId = MessageId(decoder.decodeLong())
+
+}

--- a/bridge/src/commonMain/kotlin/ru/herobrine1st/matrix/bridge/telegram/value/SerializersModule.kt
+++ b/bridge/src/commonMain/kotlin/ru/herobrine1st/matrix/bridge/telegram/value/SerializersModule.kt
@@ -5,4 +5,5 @@ import kotlinx.serialization.modules.SerializersModule
 
 fun getRemoteActorSerializersModule() = SerializersModule {
     contextual(ChatIdSerializer())
+    contextual(MessageIdSerializer())
 }

--- a/bridge/src/jvmMain/kotlin/ru/herobrine1st/matrix/bridge/telegram/Repository.jvm.kt
+++ b/bridge/src/jvmMain/kotlin/ru/herobrine1st/matrix/bridge/telegram/Repository.jvm.kt
@@ -35,7 +35,7 @@ actual suspend fun ApplicationEnvironment.createRepository(): Pair<RepositorySet
         connectionFactory = ConnectionFactories.get(ConnectionFactoryOptions.builder().apply {
             option(DRIVER, POOLING_DRIVER)
             option(PROTOCOL, "postgresql")
-            with(config.config("tor.deployment.database")) {
+            with(config.config("ktor.deployment.database")) {
                 option(HOST, property("host").getString())
                 option(PORT, property("port").getString().toIntOrNull() ?: error("Database port invalid"))
                 option(USER, property("username").getString())

--- a/bridge/src/jvmMain/resources/application.conf
+++ b/bridge/src/jvmMain/resources/application.conf
@@ -12,11 +12,11 @@ ktor {
     database {
       host = ${DATABASE_HOST}
       port = ${DATABASE_PORT}
-      name = ${DATABASE}
+      database = ${DATABASE}
       username = ${DATABASE_USERNAME}
       password = ${DATABASE_PASSWORD}
       pool {
-        idleTimeMs = ${?CONNECTION_IDLE_TIME_MS}
+        connectionIdleTimeMs = ${?CONNECTION_IDLE_TIME_MS}
         maxSize = ${?POOL_MAX_SIZE}
       }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ trixnity-bridge-repository-doublepuppeted = { module = "ru.herobrine1st.matrix:g
 ktor-server-core = { module = "io.ktor:ktor-server-core", version.ref = "ktor" }
 ktor-server-cio = { module = "io.ktor:ktor-server-cio", version.ref = "ktor" }
 ktor-server-callLogging = { module = "io.ktor:ktor-server-call-logging", version.ref = "ktor" }
+ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
 
 kotlinLogging = { module = "io.github.oshai:kotlin-logging", version = "7.0.3" }
 slf4j-simple = { module = "org.slf4j:slf4j-simple", version = "2.0.7" }


### PR DESCRIPTION
This PR fixes the following:

- Typo in connection factory configuration
- Non-matching names in default database configuration
- Lack of serializer on MessageId
- Lack of client Ktor engine
- AppServiceWorker not starting on Ktor application startup