### PR TITLE
Fix typo leading to invalid log entry

### DIFF
--- a/bridge/src/commonMain/kotlin/ru/herobrine1st/matrix/bridge/telegram/module/TrixnityModule.kt
+++ b/bridge/src/commonMain/kotlin/ru/herobrine1st/matrix/bridge/telegram/module/TrixnityModule.kt
@@ -69,7 +69,7 @@ fun Application.trixnityModule() {
             }
             // add actors from configuration
             (configActors - dbActors.keys).forEach {(id, data) ->
-                log.info("Adding actor $it to database")
+                log.info("Adding actor $id to database")
                 actorProvisionRepository.addActor(id, data)
             }
             // update existing actors


### PR DESCRIPTION
Refer to actor ID instead of Ktor application in log entry